### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ jobs:
   create-release:
     name: create-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       upload_url: ${{ steps.release.outputs.upload_url }}
     steps:
@@ -25,6 +27,8 @@ jobs:
     name: build-release
     needs: create-release
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         build: [linux-amd64, macos, windows-64bit]


### PR DESCRIPTION
Potential fix for [https://github.com/sweisser/versionfile/security/code-scanning/3](https://github.com/sweisser/versionfile/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. For this workflow:
- The `create-release` job requires `contents: read` and `contents: write` to create a release.
- The `build-release` job requires `contents: read` to check out the repository and `contents: write` to upload release assets.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, adding permissions at the job level is preferable for clarity and adherence to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
