### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
     types: [created]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/sweisser/versionfile/security/code-scanning/2](https://github.com/sweisser/versionfile/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function. Since the workflow only checks out code, runs tests, and builds the project, it likely only needs `contents: read` permissions. The `permissions` block can be added at the root level of the workflow to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
